### PR TITLE
new DWV url

### DIFF
--- a/registry/dcs-web-viewer-livemap/index.md
+++ b/registry/dcs-web-viewer-livemap/index.md
@@ -31,7 +31,7 @@ Ask the OpenKneeboard discord for help [discord](https://discord.gg/WdRvTxjwj4)
 
 ## Usage
 
-After DCS is running a mission, go to [https://dcs-web-editor.github.io/dcs-web-viewer-deploy/phantom-edition/](https://dcs-web-editor.github.io/dcs-web-viewer-deploy/phantom-edition/), preferably in Chrome/Chromium browser. Firefox may also work. Other browser may not work.
+After DCS is running a mission, go to [https://dcs-web-editor.github.io/dcs-web-viewer-deploy/live/](https://dcs-web-editor.github.io/dcs-web-viewer-deploy/live/), preferably in Chrome/Chromium browser. Firefox may also work. Other browser may not work.
 
 ### Shortcuts
 


### PR DESCRIPTION
This pull request includes a small but important change to the `registry/dcs-web-viewer-livemap/index.md` file. The change updates the URL for accessing the DCS web viewer.

* [`registry/dcs-web-viewer-livemap/index.md`](diffhunk://#diff-f45224339c5c5fd2a1d59b16778b58a8605f5a948cbb59658585b7e1fc701d04L34-R34): Updated the URL from `phantom-edition` to `live` to reflect the correct link for accessing the DCS web viewer.