### PR TITLE
Update index.md

### DIFF
--- a/registry/hot-loader/index.md
+++ b/registry/hot-loader/index.md
@@ -3,7 +3,7 @@
 [![tslua-codebot](https://img.shields.io/badge/CodeBot-tslua%20dcs-blue?logo=openai)](https://chat.openai.com/g/g-6643nUbup-tslua-dcs-codebot)
 [![patreon](https://img.shields.io/badge/Patreon-flyingdice-red?logo=patreon)](https://patreon.com/flyingdice)
 
-![logo](https://github.com/flying-dice/dcs-hot-loader/blob/main/.dropzone/index.png?raw=true)
+![logo](https://dcs-mod-manager-registry.pages.dev/hot-loader/index.png)
 
 DCS Hot Loader is a tool to allow for hot loading of lua scripts in DCS World.
 


### PR DESCRIPTION
This pull request includes a small change to the `registry/hot-loader/index.md` file. The change updates the URL of the logo image to point to a new location.

* [`registry/hot-loader/index.md`](diffhunk://#diff-6518f72b68a6903061b12a582148dfb1ddda71fb8df67d7ac4ed733d32f3d336L6-R6): Updated the URL of the logo image to `https://dcs-mod-manager-registry.pages.dev/hot-loader/index.png` from the previous GitHub URL.