### PR TITLE
feat(dcs-fiddle): bump to version 1.2.0 supporting runonstart

### DIFF
--- a/registry/dcs-fiddle/index.md
+++ b/registry/dcs-fiddle/index.md
@@ -3,7 +3,7 @@
 [![tslua-codebot](https://img.shields.io/badge/CodeBot-tslua%20dcs-blue?logo=openai)](https://chat.openai.com/g/g-6643nUbup-tslua-dcs-codebot)
 [![patreon](https://img.shields.io/badge/Patreon-flyingdice-red?logo=patreon)](https://patreon.com/flyingdice)
 
-![logo](https://github.com/flying-dice/dcsfiddle-server/blob/main/index.png?raw=true)
+![logo](https://dcs-mod-manager-registry.pages.dev/dcs-fiddle/index.png)
 
 # DCS Fiddle HTTP Server
 
@@ -14,48 +14,6 @@ This repository contains two HTTP servers designed to execute LUA scripts in DCS
 - **Execute LUA scripts:** Easily run LUA scripts in DCS World.
 - **RESTful API:** Interact via POST requests for seamless integration with tools and scripts.
 - **Swagger Integration:** View and test API endpoints with OpenAPI specifications.
-
-## Prerequisites
-
-To enable script execution, update your `MissionScripting.lua` file to allow access to `require` and `package` modules. Additionally, configure the LuaSocket package path as follows:
-
-### Updating `MissionScripting.lua`
-
-Replace your `MissionScripting.lua` file content with the following code:
-
-```lua
--- Initialization script for the Mission lua Environment (SSE)
-
-dofile('Scripts/ScriptingSystem.lua')
-
--- Sanitize Mission Scripting environment
--- WARNING: The following configuration makes some functions available, potentially exposing risks.
--- Proceed with caution if using downloaded missions.
-
-local function sanitizeModule(name)
-    _G[name] = nil
-    package.loaded[name] = nil
-end
-
-do
-    sanitizeModule('os')
-    sanitizeModule('io')
-    sanitizeModule('lfs')
-    -- _G['require'] = nil
-    _G['loadlib'] = nil
-    -- _G['package'] = nil
-end
-
-package.path = package.path .. ";.\\LuaSocket\\?.lua"
-package.cpath = package.cpath .. ";.\\LuaSocket\\?.dll"
-```
-
-## Installation
-
-Download the latest release from the [GitHub repository](https://github.com/flying-dice/dcsfiddle-server/releases).
-
-- Add the `dcs-fiddle-main.lua` file to your DCS World `%USERPROFILE%\Saved Games\DCS\Scripts\Hooks` folder.
-- Add the `dcs-fiddle-mission.lua` file to your DCS World `%USERPROFILE%\Saved Games\DCS\Scripts` folder.
 
 ## Usage
 

--- a/registry/dcs-fiddle/index.yaml
+++ b/registry/dcs-fiddle/index.yaml
@@ -10,7 +10,7 @@ tags:
   - Tool
 category: Tool
 license: GNU General Public License v3.0
-latest: 1.0.1
+latest: 1.2.0
 versions:
   - releasepage: >-
       https://github.com/flying-dice/dcsfiddle-server/releases/tag/v1.0.0
@@ -36,3 +36,16 @@ versions:
       - source: >-
           https://github.com/flying-dice/dcsfiddle-server/releases/download/v1.0.1/dcs-fiddle-mission.lua
         target: "{{DCS_USER_DIR}}/Scripts/dcs-fiddle-mission.lua"
+  - releasepage: >-
+      https://github.com/flying-dice/dcsfiddle-server/releases/tag/v1.2.0
+    name: v1.2.0
+    version: 1.2.0
+    date: 2024-12-17T17:56:00.000Z
+    assets:
+      - source: >-
+          https://github.com/flying-dice/dcsfiddle-server/releases/download/v1.2.0/dcs-fiddle-main.lua
+        target: "{{DCS_USER_DIR}}/Scripts/Hooks/dcs-fiddle-main.lua"
+      - source: >-
+          https://github.com/flying-dice/dcsfiddle-server/releases/download/v1.2.0/dcs-fiddle-mission.lua
+        target: "{{DCS_USER_DIR}}/Scripts/dcs-fiddle-mission.lua"
+        runonstart: true

--- a/src/ReleaseData.ts
+++ b/src/ReleaseData.ts
@@ -21,6 +21,12 @@ export const releaseDataSchema = z.object({
                         message:
                             "The target path cannot contain backslashes, use unix style paths i.e. '/'",
                     }),
+                runonstart: z.coerce
+                    .boolean()
+                    .optional()
+                    .describe(
+                        "Run on simulation (mission) start, note that this will execute the script before the mission environment is sanitized",
+                    ),
             }),
         )
         .describe("The array of files to install"),


### PR DESCRIPTION
This pull request includes several updates to the `registry/dcs-fiddle` documentation, configuration files, and TypeScript schema. The changes primarily focus on updating the documentation, adding new release information, and enhancing the schema validation.

Documentation updates:

* [`registry/dcs-fiddle/index.md`](diffhunk://#diff-58299290315cc4b8625bb7366907f24e3acb82d173cee5b6a4daf4a1fd09ac22L6-R6): Updated the logo URL and removed the "Prerequisites" and "Installation" sections to streamline the documentation. [[1]](diffhunk://#diff-58299290315cc4b8625bb7366907f24e3acb82d173cee5b6a4daf4a1fd09ac22L6-R6) [[2]](diffhunk://#diff-58299290315cc4b8625bb7366907f24e3acb82d173cee5b6a4daf4a1fd09ac22L18-L59)

Configuration updates:

* [`registry/dcs-fiddle/index.yaml`](diffhunk://#diff-e2bfd32b10ac2a7d68311a0888ab9cdb1c9838815aba083a7a8411b597da1426L13-R13): Updated the latest version to `1.2.0` and added details for the new release including assets and their target paths. [[1]](diffhunk://#diff-e2bfd32b10ac2a7d68311a0888ab9cdb1c9838815aba083a7a8411b597da1426L13-R13) [[2]](diffhunk://#diff-e2bfd32b10ac2a7d68311a0888ab9cdb1c9838815aba083a7a8411b597da1426R39-R51)

Schema updates:

* [`src/ReleaseData.ts`](diffhunk://#diff-d460d5dddcdc95618f1b026f22bfaaf0e6649c8f7377bef69e5681eb79299bf7R24-R29): Added an optional `runonstart` boolean property to the `releaseDataSchema` to indicate if a script should run on simulation start.